### PR TITLE
[Core] fixed typo in Model.Promotion.yml

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Promotion.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Promotion.yml
@@ -1,6 +1,6 @@
 Sylius\Component\Core\Model\Promotion:
     exclusion_policy: ALL
-    xml_root_name: product
+    xml_root_name: promotion
     properties:
         channels:
             expose: true


### PR DESCRIPTION
Fixed typo in Model.Promotion.yml for the 'xml_root_name' parameter

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8012 |
| License         | MIT |
